### PR TITLE
fix: Fixed null return from command suggester causing game crash

### DIFF
--- a/src/client/java/fr/madu59/bettercompass/config/SettingsManager.java
+++ b/src/client/java/fr/madu59/bettercompass/config/SettingsManager.java
@@ -134,7 +134,7 @@ public class SettingsManager {
                 return option.getPossibleValues().stream().map(Object::toString).collect(Collectors.toList());
             }
         }
-        return null;
+        return Collections.emptyList();
     }
 
     public static int getRGBColorFromSetting(String colorName) {


### PR DESCRIPTION
Modified line 16 in ClientCommands.java
Ensured suggestMatching() does not receive null parameters
Returns empty list instead of null